### PR TITLE
Replace `cryptography` with `pycryptodome`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for testing REST APIs with pytest-bdd.
 
  - boto3
  - [bravado_core]: support for the OpenAPI Specification v2.0. (Swagger 2)
- - cryptography
+ - PyCryptodome
  - pytcodestyle
  - [PyJWT]: JSON Web Token implementation in Python
  - pytest-bdd

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,7 @@ boto3==1.26.13
 botocore==1.29.13
 bravado-core==5.17.1
 certifi==2022.9.24
-cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==38.0.3
 exceptiongroup==1.0.4
 fqdn==1.5.1
 glob2==0.7
@@ -26,7 +24,7 @@ parse-type==0.6.0
 pluggy==1.0.0
 py==1.11.0
 pycodestyle==2.9.1
-pycparser==2.21
+pycryptodome==3.15.0
 PyJWT==2.6.0
 pyparsing==3.0.9
 pyrsistent==0.19.2


### PR DESCRIPTION
There are issue with installing `cryptography` on M1 Macs
