### PR TITLE
Reduce size of image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM python:3.10.12-alpine3.18
-
-RUN apk --no-cache --update add openssl libffi patch
+FROM python:3.10.12-alpine3.18 as builder
+RUN apk --no-cache add build-base openssl-dev libffi-dev
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+RUN --mount=type=cache,target=/root/.cache pip install wheel
 COPY requirements.txt .
-RUN apk --no-cache --update add --virtual build-dependencies build-base libffi-dev openssl-dev \
-  && pty=False python3 -m pip install --disable-pip-version-check -r requirements.txt \
-  && apk del build-dependencies
+RUN --mount=type=cache,target=/root/.cache python3 -m pip install -r requirements.txt
+
+FROM python:3.10.12-alpine3.18
+RUN apk --no-cache --update add openssl libffi patch
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 TAG ?= dintero/docker-pytest-bdd
 PYTEST_ADDOPTS ?=-vv --gherkin-terminal-reporter --cucumberjson-expanded
+DOCKER_BUILDKIT ?= 1
 
+export DOCKER_BUILDKIT
 build:
-	@docker build -t $(TAG) .
+	@docker build --tag $(TAG) .
 
 test:
 	@docker run \


### PR DESCRIPTION
Use multi-stage builds to reduce the size of the image built and fix the pip
warning about installing packages as root by installing then in virtualenv
