### PR TITLE
Use docker buildx to build multi-platform images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
       - name: build and publish docker image
         run: |
           echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin docker.io

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
       - run: make build
       - run: |
           make down test

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ TAG ?= dintero/docker-pytest-bdd
 PYTEST_ADDOPTS ?=-vv --gherkin-terminal-reporter --cucumberjson-expanded
 COMPOSE_DEFAULT_FLAGS=-f example/docker-compose.yml
 DOCKER_BUILDKIT ?= 1
+PLATFORMS ?= linux/amd64,linux/arm64
 
 .EXPORT_ALL_VARIABLES:
 PYTEST_ADDOPTS := $(PYTEST_ADDOPTS)
 
 export DOCKER_BUILDKIT
 build:
-	@docker build --tag $(TAG) .
+	@docker buildx build --platform $(PLATFORMS) --tag $(TAG) .
 
 .PHONY: down
 down:


### PR DESCRIPTION
Extends the build steps to include `docker/setup-buildx-action@v3` as
GitHub actions does by default not support multiple platforms and build
the image with platform linux/amd64 and linux/arm64
