### PR TITLE
Fix multi-platform image push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ test: down
 	PYTEST_ADDOPTS="$(PYTEST_ADDOPTS)" docker-compose $(COMPOSE_DEFAULT_FLAGS) run --service-ports --rm end-to-end-tests
 
 publish: build
-	docker push $(TAG)
+	@docker buildx build --platform $(PLATFORMS) --tag $(TAG) --push .
 
 install: build test


### PR DESCRIPTION
The image built by buildx is not by default loaded into `docker images`
list so the push failed

> docker push docker.io/***/***:latest
> An image does not exist locally with the tag: ***/***
> The push refers to repository [docker.io/***/***]
> make: *** [Makefile:23: publish] Error 1

Update the publish target to just push the image from buildx build

Blame: https://github.com/Dintero/docker-pytest-bdd/pull/48