### PR TITLE
Fix build, run `docker compose` instead of `docker-compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ build:
 
 .PHONY: down
 down:
-	docker-compose $(COMPOSE_DEFAULT_FLAGS) $@
+	docker compose $(COMPOSE_DEFAULT_FLAGS) $@
 
 test: down
-	docker-compose $(COMPOSE_DEFAULT_FLAGS) build
-	PYTEST_ADDOPTS="$(PYTEST_ADDOPTS)" docker-compose $(COMPOSE_DEFAULT_FLAGS) run --service-ports --rm end-to-end-tests
+	docker compose $(COMPOSE_DEFAULT_FLAGS) build
+	PYTEST_ADDOPTS="$(PYTEST_ADDOPTS)" docker compose $(COMPOSE_DEFAULT_FLAGS) run --service-ports --rm end-to-end-tests
 
 publish: build
 	@docker buildx build --platform $(PLATFORMS) --tag $(TAG) --push .


### PR DESCRIPTION
> docker-compose -f example/docker-compose.yml down
> make: docker-compose: No such file or directory
> make: *** [Makefile:16: down] Error 127
