### PR TITLE
Bump ecdsa from v0.18.0 to v0.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2024.7.4
 cffi==1.15.1
 charset-normalizer==3.2.0
 cryptography==43.0.1
-ecdsa==0.18.0
+ecdsa==0.19.0
 exceptiongroup==1.1.3
 fqdn==1.5.1
 glob2==0.7


### PR DESCRIPTION
> Minerva timing attack on P-256 in python-ecdsa

Fixes: CVE-2024-23342
